### PR TITLE
Fixed bug

### DIFF
--- a/backend/database/database_config.py
+++ b/backend/database/database_config.py
@@ -1,1 +1,1 @@
-type="production"
+type="local"

--- a/backend/verification/api_error_checking.py
+++ b/backend/verification/api_error_checking.py
@@ -22,6 +22,11 @@ def append_items_to_array(dictionary, result=[]):
     for key, value in dictionary.items():
         if isinstance(value, dict):
             append_items_to_array(value, result)
+        # If value is actually a list - happens when a list of values is sent through json
+        # For example when creating multiple flashcards
+        elif isinstance(value, list) :
+            for item in value:
+                append_items_to_array(item)
         else:
             result.append(value)
     return result

--- a/data.json
+++ b/data.json
@@ -11,6 +11,45 @@
                     "lastStreak": "03/03/2024"
                 },
                 "heatmapData": {}
+            },
+            "1": {
+                "userID": "1",
+                "name": "Jayme, Klein",
+                "statistics": {
+                    "streak": "0",
+                    "totalXP": "0",
+                    "weeklyXP": "0",
+                    "lastStreak": "03/03/2024"
+                },
+                "heatmapData": {},
+                "flashcards": {
+                    "109048371178679571656833207928626960824600184952382683242495299362286693266526": {
+                        "flashcardID": "109048371178679571656833207928626960824600184952382683242495299362286693266526",
+                        "flashcardName": "My new set",
+                        "flashcardDescription": "This is\nmy description",
+                        "cards": [
+                            {
+                                "front": "Front 1",
+                                "back": "Back 1",
+                                "reviewStatus": "0.0",
+                                "lastReview": "01/01/1969"
+                            }
+                        ]
+                    },
+                    "114546039906504429162281551506176130703599243813120847795015656573739354499939": {
+                        "flashcardID": "114546039906504429162281551506176130703599243813120847795015656573739354499939",
+                        "flashcardName": "My new sets",
+                        "flashcardDescription": "This is\nmy description",
+                        "cards": [
+                            {
+                                "front": "Front 1",
+                                "back": "Back 1",
+                                "reviewStatus": "0.0",
+                                "lastReview": "01/01/1969"
+                            }
+                        ]
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
# Fixed bug in creating flashcard 

## Description

Fixed a bug where dictionaries were not being turned into arrays in append_items_to_array in api_error_checking because lists weren't being handled

## Pull Requestor Checklist

- [x] Does `backend/database/database_config.py` have the type of `production`?
- [x] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
